### PR TITLE
- home: when printing HTTP addresses to console, use all IP addresses

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -645,8 +645,10 @@ func printHTTPAddresses(proto string) {
 		}
 
 		for _, iface := range ifaces {
-			address = net.JoinHostPort(iface.Addresses[0], port)
-			log.Printf("Go to %s://%s", proto, address)
+			for _, addr := range iface.Addresses {
+				address = net.JoinHostPort(addr, strconv.Itoa(config.BindPort))
+				log.Printf("Go to %s://%s", proto, address)
+			}
 		}
 	} else {
 		address = net.JoinHostPort(config.BindHost, port)


### PR DESCRIPTION
Close #1856

Squashed commit of the following:

commit 47ff99f147216bf28f1395847148f084b9dd4deb
Author: Simon Zolin <s.zolin@adguard.com>
Date:   Thu Jul 2 14:27:03 2020 +0300

    - home: when printing HTTP addresses to console, use all IP addresses